### PR TITLE
fix: problem of transcription after a cursor move

### DIFF
--- a/app/src/main/java/cm/pythonbrad/afrim/latin/LatinIME.java
+++ b/app/src/main/java/cm/pythonbrad/afrim/latin/LatinIME.java
@@ -578,6 +578,8 @@ public class LatinIME extends InputMethodService
   public void onWindowShown() {
     super.onWindowShown();
     if (isInputViewShown()) setNavigationBarColor();
+    // We assume that the cursor has been moved and we clear the afrim.
+    mAfrim.clear();
   }
 
   @Override


### PR DESCRIPTION
Now, the afrim will be clear each time the cursor move.