### PR TITLE
chore(afrim-jni): update afrim dependencies 

### DIFF
--- a/app/src/main/jni/afrim_jni/Cargo.toml
+++ b/app/src/main/jni/afrim_jni/Cargo.toml
@@ -15,9 +15,9 @@ inhibit = ["afrim-preprocessor/inhibit"]
 rhai = ["afrim-translator/rhai", "afrim-config/rhai"]
 
 [dependencies]
-afrim-config = { version = "0.4.4", default-features = false, git = "https://github.com/pythonbrad/afrim", rev = "4a814b1" }
-afrim-preprocessor = { version = "0.6.0", default-features = false, git = "https://github.com/pythonbrad/afrim", rev = "4a814b1", features = ["serde"] }
-afrim-translator = { version = "0.1.4", default-features = false, git = "https://github.com/pythonbrad/afrim", rev = "4a814b1" }
+afrim-config = { version = "0.4.4", default-features = false, git = "https://github.com/pythonbrad/afrim", rev = "81c8a2e" }
+afrim-preprocessor = { version = "0.6.0", default-features = false, git = "https://github.com/pythonbrad/afrim", rev = "81c8a2e", features = ["serde"] }
+afrim-translator = { version = "0.1.4", default-features = false, git = "https://github.com/pythonbrad/afrim", rev = "81c8a2e" }
 anyhow = "1.0.81"
 indexmap = "2.2.3"
 jni = "0.21.1"

--- a/app/src/main/jni/afrim_jni/Cargo.toml
+++ b/app/src/main/jni/afrim_jni/Cargo.toml
@@ -15,9 +15,10 @@ inhibit = ["afrim-preprocessor/inhibit"]
 rhai = ["afrim-translator/rhai", "afrim-config/rhai"]
 
 [dependencies]
-afrim-config = { version = "0.4.4", default-features = false }
-afrim-preprocessor = { version = "0.6.0", default-features = false, features = ["serde"] }
-afrim-translator = { version = "0.1.4", default-features = false }
+afrim-config = { version = "0.4.4", default-features = false, git = "https://github.com/pythonbrad/afrim", rev = "4a814b1" }
+afrim-preprocessor = { version = "0.6.0", default-features = false, git = "https://github.com/pythonbrad/afrim", rev = "4a814b1", features = ["serde"] }
+afrim-translator = { version = "0.1.4", default-features = false, git = "https://github.com/pythonbrad/afrim", rev = "4a814b1" }
+anyhow = "1.0.81"
 indexmap = "2.2.3"
 jni = "0.21.1"
 once_cell = "1.19.0"

--- a/app/src/main/jni/afrim_jni/src/afrim_api.rs
+++ b/app/src/main/jni/afrim_jni/src/afrim_api.rs
@@ -81,7 +81,7 @@ impl Afrim {
 
     /// Commits the text.
     pub fn commit_text(&mut self, text: String) {
-        self.preprocessor.commit(&text);
+        self.preprocessor.commit(text);
     }
 
     /// Returns the next command to be executed.
@@ -99,7 +99,7 @@ impl Afrim {
 
     /// Clears the afrim.
     pub fn clear(&mut self) {
-        self.preprocessor.commit("");
+        self.preprocessor.commit("".to_owned());
         self.preprocessor.clear_queue();
     }
 }


### PR DESCRIPTION
### Issues
- #21 

### Change
We can't wait the release of the afrim to get some important updates.
We will fetch the afrim crate directly from github.